### PR TITLE
Add selectable email provider

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -316,3 +316,30 @@ Toolkit for importing data from existing IMAP servers.
 *   **D. Target Common IMAP Servers:** Dovecot, Cyrus, Exchange, Gmail, Office 365.
 ---
 This document provides a comprehensive overview of the planned architecture. Each section would require further detailed design and specification during the implementation phases.
+
+## Email Providers
+
+The `email_sender.py` module offers a simple utility for sending mail through either Amazon SES or an IMAP server. Choose the provider when creating an `EmailSender` instance:
+
+```python
+from email_sender import EmailSender
+
+# Using Amazon SES
+ses_sender = EmailSender(
+    provider="ses",
+    region_name="us-east-1",
+)
+ses_sender.send_email("from@example.com", ["to@example.com"], "Subject", "Body")
+
+# Using an IMAP server
+imap_sender = EmailSender(
+    provider="imap",
+    server="imap.example.com",
+    username="user",
+    password="pass",
+    mailbox="INBOX",
+)
+imap_sender.send_email("from@example.com", ["to@example.com"], "Subject", "Body")
+```
+
+The IMAP option appends the message to the specified mailbox, while the SES option sends mail using the configured AWS region.

--- a/email_sender.py
+++ b/email_sender.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from typing import List
+import os
+import imaplib
+from email.mime.text import MIMEText
+
+import boto3
+
+
+class EmailProvider:
+    """Abstract base email provider."""
+
+    def send_email(self, from_addr: str, to_addrs: List[str], subject: str, body: str) -> None:
+        raise NotImplementedError
+
+
+class SESEmailProvider(EmailProvider):
+    """Send email using Amazon SES."""
+
+    def __init__(self, region_name: str | None = None):
+        region = region_name or os.environ.get("AWS_REGION", "us-east-1")
+        self.client = boto3.client("ses", region_name=region)
+
+    def send_email(self, from_addr: str, to_addrs: List[str], subject: str, body: str) -> None:
+        self.client.send_email(
+            Source=from_addr,
+            Destination={"ToAddresses": list(to_addrs)},
+            Message={
+                "Subject": {"Data": subject},
+                "Body": {"Text": {"Data": body}},
+            },
+        )
+
+
+class IMAPEmailProvider(EmailProvider):
+    """Send email by appending the message to a mailbox via IMAP."""
+
+    def __init__(self, server: str, username: str, password: str, mailbox: str = "INBOX"):
+        self.server = server
+        self.username = username
+        self.password = password
+        self.mailbox = mailbox
+
+    def send_email(self, from_addr: str, to_addrs: List[str], subject: str, body: str) -> None:
+        msg = MIMEText(body)
+        msg["From"] = from_addr
+        msg["To"] = ", ".join(to_addrs)
+        msg["Subject"] = subject
+
+        with imaplib.IMAP4_SSL(self.server) as imap:
+            imap.login(self.username, self.password)
+            imap.append(self.mailbox, None, None, msg.as_bytes())
+            imap.logout()
+
+
+class EmailSender:
+    """Factory class to send email using a chosen provider."""
+
+    def __init__(self, provider: str, **kwargs):
+        provider = provider.lower()
+        if provider == "ses":
+            self.provider: EmailProvider = SESEmailProvider(kwargs.get("region_name"))
+        elif provider == "imap":
+            required = {"server", "username", "password"}
+            missing = required - kwargs.keys()
+            if missing:
+                raise ValueError(f"Missing IMAP config keys: {', '.join(sorted(missing))}")
+            self.provider = IMAPEmailProvider(
+                kwargs["server"],
+                kwargs["username"],
+                kwargs["password"],
+                kwargs.get("mailbox", "INBOX"),
+            )
+        else:
+            raise ValueError(f"Unknown provider: {provider}")
+
+    def send_email(self, from_addr: str, to_addrs: List[str], subject: str, body: str) -> None:
+        self.provider.send_email(from_addr, to_addrs, subject, body)


### PR DESCRIPTION
## Summary
- add new `email_sender` module to send mail via Amazon SES or IMAP
- document how to use the email provider in README

## Testing
- `python -m py_compile email_sender.py`
- `python -m py_compile api_server.py imap_mcp_server/server.py email_sender.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d119fb62c8331a7ddec1d32a46d5e